### PR TITLE
Implement phone contact request, scheduling DB and logging

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -7,13 +7,25 @@ from typing import Dict, List
 
 from openai import OpenAI
 
-from db import get_lead_by_telegram_id, save_lead
+from datetime import datetime
+
+from db import (
+    get_lead_by_telegram_id,
+    create_lead,
+    update_lead,
+    list_services,
+    list_open_times,
+    schedule_appointment,
+    update_sale_temperature,
+    get_lead_id,
+)
 
 
 SYSTEM_PROMPT = (
     "You are AURA, a polite assistant helping new psychology clients schedule an appointment. "
-    "Gather the client's full name, requested service type, preferred time, and phone number. "
-    "Once all details are collected, confirm and end the conversation."
+    "You know the current date and time and can check prices and availability using the provided tools. "
+    "Gather the client's name, service of interest, preferred time and phone number, updating the database as you learn new facts. "
+    "Always keep the conversation short and helpful."
 )
 
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY", ""))
@@ -25,13 +37,21 @@ active_sessions: Dict[int, List[Dict[str, str]]] = {}
 def start_session(chat_id: int) -> None:
     """Initialize conversation history for a Telegram chat."""
     if chat_id not in active_sessions:
-        active_sessions[chat_id] = [{"role": "system", "content": SYSTEM_PROMPT}]
+        now = datetime.utcnow().isoformat(sep=" ", timespec="minutes")
+        services = ", ".join([f"{s[1]} (${s[2]})" for s in list_services()])
+        open_times = ", ".join([
+            f"{ot[0]}:{ot[1]}-{ot[2]}" for ot in list_open_times()
+        ])
+        system_msg = (
+            f"{SYSTEM_PROMPT} Current datetime: {now}. Available services: {services}. "
+            f"Opening hours (day:open-close): {open_times}."
+        )
+        active_sessions[chat_id] = [{"role": "system", "content": system_msg}]
 
 
 def handle_message(chat_id: int, text: str) -> str:
     """Process an incoming message and return the assistant's reply."""
-    if get_lead_by_telegram_id(chat_id):
-        return "Thank you, we already have your information. We'll be in touch soon."
+    create_lead(chat_id)
 
     start_session(chat_id)
     msgs = active_sessions[chat_id]
@@ -41,8 +61,8 @@ def handle_message(chat_id: int, text: str) -> str:
         {
             "type": "function",
             "function": {
-                "name": "save_lead",
-                "description": "Store prospect data once all fields are collected",
+                "name": "update_lead",
+                "description": "Update lead information as soon as it is known",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -51,10 +71,36 @@ def handle_message(chat_id: int, text: str) -> str:
                         "preferred_time": {"type": "string"},
                         "phone": {"type": "string"},
                     },
-                    "required": ["name", "service", "preferred_time", "phone"],
                 },
             },
-        }
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "schedule_appointment",
+                "description": "Schedule a session for the lead",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "service_id": {"type": "integer"},
+                        "scheduled_time": {"type": "string"},
+                    },
+                    "required": ["service_id", "scheduled_time"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "update_sale_temperature",
+                "description": "Update the lead's sale temperature (0-100)",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"temperature": {"type": "integer"}},
+                    "required": ["temperature"],
+                },
+            },
+        },
     ]
 
     response = client.chat.completions.create(
@@ -69,16 +115,20 @@ def handle_message(chat_id: int, text: str) -> str:
 
     if message.tool_calls:
         for call in message.tool_calls:
-            if call.function.name == "save_lead":
+            if call.function.name == "update_lead":
                 args = json.loads(call.function.arguments)
-                save_lead(
-                    telegram_id=chat_id,
-                    name=args["name"],
-                    service=args["service"],
-                    preferred_time=args["preferred_time"],
-                    phone=args["phone"],
-                )
-                msgs.append({"role": "assistant", "content": "Thank you! We'll reach out soon."})
-                return "Thank you! We'll reach out soon."
+                update_lead(chat_id, **args)
+            elif call.function.name == "schedule_appointment":
+                args = json.loads(call.function.arguments)
+                lead_id = get_lead_id(chat_id)
+                if lead_id:
+                    schedule_appointment(
+                        lead_id=lead_id,
+                        service_id=args["service_id"],
+                        scheduled_time=args["scheduled_time"],
+                    )
+            elif call.function.name == "update_sale_temperature":
+                args = json.loads(call.function.arguments)
+                update_sale_temperature(chat_id, int(args["temperature"]))
 
     return message.content or ""

--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from typing import Any, Dict
 
 from flask import Flask, request, abort
@@ -9,11 +10,19 @@ import requests
 
 
 from ai import handle_message
-from db import init_db
+from db import init_db, get_lead_by_telegram_id, create_lead, update_lead
 
 TELEGRAM_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 WEBHOOK_SECRET = os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
 TELEGRAM_API_URL = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s %(levelname)s:%(name)s: %(message)s",
+    filename="server.log",
+    filemode="a",
+)
+logger = logging.getLogger(__name__)
 
 init_db()
 app = Flask(__name__)
@@ -26,18 +35,46 @@ def telegram_webhook() -> Dict[str, Any]:
         abort(403)
 
     data = request.get_json(force=True)
+    logger.debug(f"update received: {data}")
     message = data.get("message", {})
     chat = message.get("chat", {})
     chat_id = chat.get("id")
     text = message.get("text", "")
+    contact = message.get("contact")
 
     if chat_id is None:
         return {}
+
+    create_lead(chat_id)
+
+    if contact:
+        update_lead(
+            chat_id,
+            phone=contact.get("phone_number"),
+            name=contact.get("first_name"),
+        )
+
+    lead = get_lead_by_telegram_id(chat_id)
+
+    if (lead is None or lead[5] is None) and not contact:
+        keyboard = {
+            "keyboard": [[{"text": "Compartir tu contacto.", "request_contact": True}]],
+            "one_time_keyboard": True,
+        }
+        payload = {
+            "chat_id": chat_id,
+            "text": "Por favor comparte tu n\u00famero de tel\u00e9fono.",
+            "reply_markup": keyboard,
+        }
+        requests.post(TELEGRAM_API_URL, json=payload)
+        logger.debug(f"requested contact from {chat_id}")
+        return {"ok": True}
 
     reply = handle_message(chat_id, text)
 
     payload = {"chat_id": chat_id, "text": reply}
     requests.post(TELEGRAM_API_URL, json=payload)
+    logger.debug(f"sent reply to {chat_id}: {reply}")
 
     return {"ok": True}
 

--- a/db.py
+++ b/db.py
@@ -7,7 +7,7 @@ DB_PATH = Path("crm.db")
 
 
 def init_db() -> None:
-    """Initialize the leads table if it does not exist."""
+    """Initialize database tables."""
     with closing(sqlite3.connect(DB_PATH)) as conn:
         conn.execute(
             """
@@ -18,21 +18,64 @@ def init_db() -> None:
                 service TEXT,
                 preferred_time TEXT,
                 phone TEXT,
+                sale_temperature INTEGER DEFAULT 10,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS services (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT,
+                price REAL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS open_times (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                day_of_week INTEGER,
+                open_time TEXT,
+                close_time TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS appointments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                lead_id INTEGER,
+                service_id INTEGER,
+                scheduled_time TEXT
             )
             """
         )
         conn.commit()
 
 
-def save_lead(
-    telegram_id: int, name: str, service: str, preferred_time: str, phone: str
-) -> None:
-    """Save a collected lead into the database."""
+def create_lead(telegram_id: int) -> None:
+    """Ensure a lead entry exists."""
     with closing(sqlite3.connect(DB_PATH)) as conn:
         conn.execute(
-            "INSERT OR REPLACE INTO leads(telegram_id, name, service, preferred_time, phone) VALUES (?,?,?,?,?)",
-            (telegram_id, name, service, preferred_time, phone),
+            "INSERT OR IGNORE INTO leads(telegram_id) VALUES (?)",
+            (telegram_id,),
+        )
+        conn.commit()
+
+
+def update_lead(telegram_id: int, **fields) -> None:
+    """Update given fields for a lead."""
+    if not fields:
+        return
+    columns = ", ".join([f"{k}=?" for k in fields.keys()])
+    values = list(fields.values())
+    values.append(telegram_id)
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        conn.execute(
+            f"UPDATE leads SET {columns} WHERE telegram_id=?",
+            values,
         )
         conn.commit()
 
@@ -45,6 +88,46 @@ def get_lead_by_telegram_id(telegram_id: int):
             (telegram_id,),
         )
         return cur.fetchone()
+
+
+def get_lead_id(telegram_id: int) -> int | None:
+    """Return the internal lead id for a telegram user."""
+    row = get_lead_by_telegram_id(telegram_id)
+    return row[0] if row else None
+
+
+def list_services():
+    """Return all services with pricing."""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        cur = conn.execute("SELECT id, name, price FROM services")
+        return cur.fetchall()
+
+
+def list_open_times():
+    """Return weekly open times."""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        cur = conn.execute("SELECT day_of_week, open_time, close_time FROM open_times")
+        return cur.fetchall()
+
+
+def schedule_appointment(lead_id: int, service_id: int, scheduled_time: str) -> None:
+    """Store a new appointment if the slot is free."""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        cur = conn.execute(
+            "SELECT COUNT(*) FROM appointments WHERE scheduled_time=?",
+            (scheduled_time,),
+        )
+        if cur.fetchone()[0] == 0:
+            conn.execute(
+                "INSERT INTO appointments(lead_id, service_id, scheduled_time) VALUES (?,?,?)",
+                (lead_id, service_id, scheduled_time),
+            )
+            conn.commit()
+
+
+def update_sale_temperature(telegram_id: int, temperature: int) -> None:
+    """Update a lead's sale temperature."""
+    update_lead(telegram_id, sale_temperature=temperature)
 
       
 # Ensure the database exists when this module is imported


### PR DESCRIPTION
## Summary
- extend database schema for services, open times, appointments and sale temperature
- allow creating/updating leads incrementally and scheduling sessions
- improve AI conversation logic with new tools and dynamic system context
- log incoming webhook data and conversation replies
- request user's phone number via Telegram contact button on first contact

## Testing
- `python -m py_compile ai.py bot.py db.py`
- `pytest -q`
- `pip install flask requests openai==1.97.0`

------
https://chatgpt.com/codex/tasks/task_e_687a626335e4832fb907a5486b72c8c5