### PR TITLE
Improve emergency handling and lead updates

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -7,7 +7,7 @@ from typing import Dict, List
 
 from openai import OpenAI
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from db import (
     get_lead_by_telegram_id,
@@ -39,11 +39,16 @@ model = os.environ.get("OPENAI_CHAT_MODEL", "gpt-4.1")
 
 # In-memory session store
 active_sessions: Dict[int, List[Dict[str, str]]] = {}
+# Tracks if a conversation has been escalated due to emergency.
+escalated_flags: Dict[int, bool] = {}
+
+# Time zone offset for the user (UTC-5)
+USER_TZ_OFFSET = timedelta(hours=-5)
 
 
 def start_session(telegram_id: int) -> None:
     """Initialize conversation history for a Telegram user."""
-    now = datetime.utcnow().isoformat(sep=" ", timespec="minutes")
+    now = (datetime.utcnow() + USER_TZ_OFFSET).isoformat(sep=" ", timespec="minutes")
     services = ", ".join([f"{s[1]} (${s[2]})" for s in list_services()])
     open_times = ", ".join([
         f"{ot[0]}:{ot[1]}-{ot[2]}" for ot in list_open_times()
@@ -61,13 +66,14 @@ def start_session(telegram_id: int) -> None:
             lead_info_parts.append(f"phone: {lead[5]}")
     lead_info = " Known lead data: " + ", ".join(lead_info_parts) + "." if lead_info_parts else ""
     system_msg = (
-        f"{SYSTEM_PROMPT} Current datetime: {now}. Available services: {services}. "
+        f"{SYSTEM_PROMPT} Current datetime (UTC-05:00): {now}. Available services: {services}. "
         f"Opening hours (day:open-close): {open_times}.{lead_info}"
     )
     if telegram_id in active_sessions:
         active_sessions[telegram_id][0] = {"role": "system", "content": system_msg}
     else:
         active_sessions[telegram_id] = [{"role": "system", "content": system_msg}]
+        escalated_flags[telegram_id] = False
 
 
 def handle_message(telegram_id: int, text: str) -> str:
@@ -205,17 +211,35 @@ def handle_message(telegram_id: int, text: str) -> str:
             if call.function.name == "update_lead":
                 args = json.loads(call.function.arguments)
                 update_lead(telegram_id, **args)
+                # raise sale temperature when we learn key info
+                if any(k in args for k in ("service", "preferred_time")):
+                    update_sale_temperature(telegram_id, 70)
+                elif "name" in args and args["name"] and len(args["name"]) > 1:
+                    update_sale_temperature(telegram_id, 30)
                 result = "ok"
             elif call.function.name == "schedule_appointment":
                 args = json.loads(call.function.arguments)
-                lead_id = get_lead_id(telegram_id)
-                success = False
-                if lead_id:
-                    success = schedule_appointment(
-                        lead_id=lead_id,
-                        service_id=args["service_id"],
-                        scheduled_time=args["scheduled_time"],
-                    )
+                if escalated_flags.get(telegram_id):
+                    success = False
+                else:
+                    lead_id = get_lead_id(telegram_id)
+                    success = False
+                    if lead_id:
+                        success = schedule_appointment(
+                            lead_id=lead_id,
+                            service_id=args["service_id"],
+                            scheduled_time=args["scheduled_time"],
+                        )
+                        if success:
+                            # store service and time and raise temperature
+                            from db import get_service_name
+                            service_name = get_service_name(args["service_id"])
+                            update_lead(
+                                telegram_id,
+                                service=service_name,
+                                preferred_time=args["scheduled_time"],
+                            )
+                            update_sale_temperature(telegram_id, 100)
                 result = str(success).lower()
             elif call.function.name == "update_sale_temperature":
                 args = json.loads(call.function.arguments)
@@ -223,9 +247,12 @@ def handle_message(telegram_id: int, text: str) -> str:
                 result = "ok"
             elif call.function.name == "check_availability":
                 args = json.loads(call.function.arguments)
-                available = check_availability(
-                    args["service_id"], args["proposed_time"]
-                )
+                if escalated_flags.get(telegram_id):
+                    available = False
+                else:
+                    available = check_availability(
+                        args["service_id"], args["proposed_time"]
+                    )
                 result = {"available": available}
             elif call.function.name == "suggest_alternative_slots":
                 args = json.loads(call.function.arguments)
@@ -246,6 +273,7 @@ def handle_message(telegram_id: int, text: str) -> str:
             elif call.function.name == "escalate_case":
                 args = json.loads(call.function.arguments)
                 lead_id = get_lead_id(telegram_id)
+                escalated_flags[telegram_id] = True
                 if lead_id:
                     escalate_case(
                         lead_id=lead_id,

--- a/bot.py
+++ b/bot.py
@@ -25,6 +25,7 @@ logging.basicConfig(
     filename="server.log",
     filemode="a",
 )
+logging.getLogger("urllib3").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 init_db()
@@ -56,7 +57,6 @@ def telegram_webhook() -> Dict[str, Any]:
         update_lead(
             telegram_id,
             phone=contact.get("phone_number"),
-            name=contact.get("first_name"),
         )
 
     lead = get_lead_by_telegram_id(telegram_id)

--- a/db.py
+++ b/db.py
@@ -150,6 +150,17 @@ def list_services():
         return cur.fetchall()
 
 
+def get_service_name(service_id: int) -> str | None:
+    """Return the service name for a given id."""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        cur = conn.execute(
+            "SELECT name FROM services WHERE id=?",
+            (service_id,),
+        )
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
 def list_open_times():
     """Return weekly open times."""
     with closing(sqlite3.connect(DB_PATH)) as conn:


### PR DESCRIPTION
## Summary
- ensure contact share only records phone number
- lower verbosity of `urllib3` logs
- store session timezone in UTC-5
- track emergencies to block scheduling
- record service and preferred time on scheduling
- expose helper to fetch service names

## Testing
- `python -m py_compile ai.py bot.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_687aba720be0832f87f06af86cf61d10