### PR TITLE
Automate bot creation via YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,41 @@ AURA (Automated Unified Response Agent) is an AI-powered Telegram assistant for 
 - `crm.db` – SQLite database created at runtime.
 
 ## Setup
-1. Install dependencies (requires `openai` version 1.97.0):
+1. **Create a Telegram bot**
+   1. Open a chat with [@BotFather](https://t.me/BotFather) in Telegram.
+   2. Send `/newbot` and follow the prompts to choose a name and username.
+   3. BotFather will return a token – copy it and set it as `TELEGRAM_BOT_TOKEN`.
+   4. (Optional) Use `/setdescription` and `/setabouttext` to customise your bot.
+2. *(For automated setup)* Create Telegram API credentials by logging in to [my.telegram.org](https://my.telegram.org) and generating an **API ID** and **API hash**.
+3. Install dependencies (requires `openai` version 1.97.0):
    ```bash
    pip install flask requests openai==1.97.0
    ```
-2. Copy `.env` and fill in your keys:
+4. Copy `.env` and fill in your keys:
    ```bash
    cp .env .env.local
    # edit .env.local with OPENAI_API_KEY, TELEGRAM_BOT_TOKEN and TELEGRAM_WEBHOOK_SECRET
    ```
-3. Run the server:
+5. Run the server:
     ```bash
     python bot.py
     ```
-4. Configure your Telegram bot webhook to point to `https://<your-domain>/telegram` using the secret token from `TELEGRAM_WEBHOOK_SECRET`.
+6. Expose the server publicly (e.g. via a domain or with ngrok) and configure the Telegram webhook:
+   ```bash
+   curl -X POST https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook \
+        -d "url=https://<your-domain>/telegram&secret_token=$TELEGRAM_WEBHOOK_SECRET"
+   ```
 
 The bot converses with prospects, collects their name, service type, preferred schedule and phone number, then stores the information in `crm.db`.
 
 `db.py` seeds a few sample services and opening hours for Clara's practice on the first run. Leads are stored using the user's Telegram ID (not the chat ID) so conversation history and appointments are tied to each person.
+
+## Automated deployment
+To bootstrap the bot configuration from a single YAML file, install the extra dependencies and run `setup_bot.py`:
+
+```bash
+pip install pyyaml python-dotenv telethon requests
+python setup_bot.py example_config.yml
+```
+
+The YAML must contain your Telegram API credentials (`telegram_api_id`, `telegram_api_hash` and `telegram_phone`) and bot details (`bot_name`, `bot_username`, `telegram_webhook_url`, `telegram_webhook_secret`). OpenAI keys are also required but are not generated automatically. Optional `services` and `open_times` entries seed the database. See `example_config.yml` for the full format. When run, the script will create the bot via BotFather, register the webhook and write `.env.local` and `crm.db`.

--- a/db.py
+++ b/db.py
@@ -259,6 +259,27 @@ def escalate_case(lead_id: int, reason: str, details: str | None = None) -> None
         )
         conn.commit()
 
+
+def seed_services(services: list[tuple[str, float]]) -> None:
+    """Replace the services table with the given list."""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        conn.execute("DELETE FROM services")
+        conn.executemany(
+            "INSERT INTO services(name, price) VALUES (?, ?)", services
+        )
+        conn.commit()
+
+
+def seed_open_times(times: list[tuple[int, str, str]]) -> None:
+    """Replace opening hours with the given schedule."""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        conn.execute("DELETE FROM open_times")
+        conn.executemany(
+            "INSERT INTO open_times(day_of_week, open_time, close_time) VALUES (?,?,?)",
+            times,
+        )
+        conn.commit()
+
       
 # Ensure the database exists when this module is imported
 init_db()

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,0 +1,35 @@
+openai_api_key: YOUR_OPENAI_KEY
+openai_chat_model: gpt-4.1
+telegram_api_id: 123456
+telegram_api_hash: your_api_hash
+telegram_phone: '+1234567890'
+bot_name: 'Clara Therapy Bot'
+bot_username: 'clara_therapy_bot'
+telegram_webhook_url: 'https://your-domain.com/telegram'
+telegram_webhook_secret: your_webhook_secret
+bot_description: 'Automated intake assistant for Clara.'
+bot_about: 'Handles appointment scheduling and queries.'
+services:
+  - name: 'Initial consultation'
+    price: 60.0
+  - name: 'Therapy session'
+    price: 80.0
+open_times:
+  - day: 1
+    open: '14:00'
+    close: '22:00'
+  - day: 2
+    open: '14:00'
+    close: '22:00'
+  - day: 3
+    open: '14:00'
+    close: '22:00'
+  - day: 4
+    open: '14:00'
+    close: '22:00'
+  - day: 5
+    open: '14:00'
+    close: '22:00'
+  - day: 6
+    open: '14:00'
+    close: '22:00'

--- a/setup_bot.py
+++ b/setup_bot.py
@@ -1,0 +1,146 @@
+"""Bootstrap deployment from a YAML configuration."""
+
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+import yaml
+from telethon import TelegramClient
+import asyncio
+
+from db import init_db, seed_services, seed_open_times
+
+
+async def create_telegram_bot(config: Dict[str, Any]) -> str:
+    """Interact with BotFather to create a bot and return its token."""
+    api_id = int(config["telegram_api_id"])
+    api_hash = config["telegram_api_hash"]
+    phone = config["telegram_phone"]
+    name = config["bot_name"]
+    username = config["bot_username"]
+
+    client = TelegramClient("bot_setup", api_id, api_hash)
+    await client.start(phone=phone)
+
+    async with client.conversation("BotFather") as conv:
+        await conv.send_message("/newbot")
+        await conv.get_response()
+        await conv.send_message(name)
+        await conv.get_response()
+        await conv.send_message(username)
+        final = await conv.get_response()
+    await client.disconnect()
+
+    match = re.search(r"(\d+:[A-Za-z0-9_-]+)", final.text)
+    if not match:
+        raise RuntimeError("Failed to obtain bot token from BotFather")
+    return match.group(1)
+
+
+async def customise_bot(config: Dict[str, Any], bot_token: str) -> None:
+    """Set description and about text for the bot if provided."""
+    api_id = int(config["telegram_api_id"])
+    api_hash = config["telegram_api_hash"]
+    phone = config["telegram_phone"]
+    username = config["bot_username"]
+    description = config.get("bot_description")
+    about = config.get("bot_about")
+
+    client = TelegramClient("bot_setup", api_id, api_hash)
+    await client.start(phone=phone)
+    async with client.conversation("BotFather") as conv:
+        if description:
+            await conv.send_message("/setdescription")
+            await conv.get_response()
+            await conv.send_message(username)
+            await conv.get_response()
+            await conv.send_message(description)
+            await conv.get_response()
+
+        if about:
+            await conv.send_message("/setabouttext")
+            await conv.get_response()
+            await conv.send_message(username)
+            await conv.get_response()
+            await conv.send_message(about)
+            await conv.get_response()
+    await client.disconnect()
+
+
+def register_webhook(bot_token: str, url: str, secret: str) -> None:
+    """Configure the Telegram webhook."""
+    resp = requests.post(
+        f"https://api.telegram.org/bot{bot_token}/setWebhook",
+        data={"url": url, "secret_token": secret},
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+
+REQUIRED_KEYS = [
+    "openai_api_key",
+    "telegram_api_id",
+    "telegram_api_hash",
+    "telegram_phone",
+    "bot_name",
+    "bot_username",
+    "telegram_webhook_url",
+    "telegram_webhook_secret",
+]
+
+
+def write_env(config: dict, bot_token: str) -> None:
+    """Generate .env.local with the new bot token and OpenAI settings."""
+    env_lines = []
+    for key in [
+        "openai_api_key",
+        "openai_chat_model",
+        "openai_vector_store_id",
+        "openai_tts_model",
+    ]:
+        value = config.get(key)
+        if value is not None:
+            env_lines.append(f"{key.upper()}={value}")
+    env_lines.append(f"TELEGRAM_BOT_TOKEN={bot_token}")
+    env_lines.append(f"TELEGRAM_WEBHOOK_SECRET={config['telegram_webhook_secret']}")
+    Path(".env.local").write_text("\n".join(env_lines) + "\n")
+
+
+def seed_db(config: dict) -> None:
+    if Path("crm.db").exists():
+        Path("crm.db").unlink()
+    init_db()
+    services = config.get("services")
+    if services:
+        seed_services([(s["name"], float(s["price"])) for s in services])
+    times = config.get("open_times")
+    if times:
+        seed_open_times(
+            [
+                (int(t["day"]), t["open"], t["close"])  # type: ignore
+                for t in times
+            ]
+        )
+
+
+def main(path: str) -> None:
+    config = yaml.safe_load(Path(path).read_text())
+    missing = [k for k in REQUIRED_KEYS if k not in config]
+    if missing:
+        raise SystemExit(f"Missing required keys: {', '.join(missing)}")
+
+    bot_token = asyncio.run(create_telegram_bot(config))
+    asyncio.run(customise_bot(config, bot_token))
+    register_webhook(bot_token, config["telegram_webhook_url"], config["telegram_webhook_secret"])
+    write_env(config, bot_token)
+    seed_db(config)
+    print("Bot created and deployment files generated: .env.local and crm.db")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python setup_bot.py <config.yml>")
+        raise SystemExit(1)
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary
- expand YAML-driven deployment to create Telegram bot via BotFather
- add webhook registration and bot customisation steps
- document updated YAML format and automated setup procedure

## Testing
- `python -m py_compile bot.py ai.py db.py setup_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6887b12b655c832f8737e420a2b72eb2