### PR TITLE
Add Docker and ngrok deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.db
+.env*
+.ngrok*
+bot_setup*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+ENV PYTHONUNBUFFERED=1
+CMD ["python", "bot.py"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AURA (Automated Unified Response Agent) is an AI-powered Telegram assistant for 
 2. *(For automated setup)* Create Telegram API credentials by logging in to [my.telegram.org](https://my.telegram.org) and generating an **API ID** and **API hash**.
 3. Install dependencies (requires `openai` version 1.97.0):
    ```bash
-   pip install flask requests openai==1.97.0
+   pip install -r requirements.txt
    ```
 4. Copy `.env` and fill in your keys:
    ```bash
@@ -48,4 +48,9 @@ pip install pyyaml python-dotenv telethon requests
 python setup_bot.py example_config.yml
 ```
 
-The YAML must contain your Telegram API credentials (`telegram_api_id`, `telegram_api_hash` and `telegram_phone`) and bot details (`bot_name`, `bot_username`, `telegram_webhook_url`, `telegram_webhook_secret`). OpenAI keys are also required but are not generated automatically. Optional `services` and `open_times` entries seed the database. See `example_config.yml` for the full format. When run, the script will create the bot via BotFather, register the webhook and write `.env.local` and `crm.db`.
+The YAML must contain your Telegram API credentials (`telegram_api_id`, `telegram_api_hash` and `telegram_phone`) and bot details (`bot_name`, `bot_username`, `telegram_webhook_secret`). OpenAI keys are also required but are not generated automatically. Optional `services` and `open_times` entries seed the database. See `example_config.yml` for the full format.
+
+When run, `setup_bot.py` now also builds the Docker image if needed, pushes it to Docker Hub, starts an ngrok tunnel and registers the resulting URL as the Telegram webhook. Finally the bot container is launched automatically.
+
+## Docker deployment
+The repository includes a `Dockerfile` so the bot can run anywhere with Docker installed. The image installs all requirements and launches `bot.py` on port 8000. `setup_bot.py` will push this image to Docker Hub (configured via the YAML file) if it isn't already available and then use it to run your bot container.

--- a/example_config.yml
+++ b/example_config.yml
@@ -5,7 +5,6 @@ telegram_api_hash: your_api_hash
 telegram_phone: '+1234567890'
 bot_name: 'Clara Therapy Bot'
 bot_username: 'clara_therapy_bot'
-telegram_webhook_url: 'https://your-domain.com/telegram'
 telegram_webhook_secret: your_webhook_secret
 bot_description: 'Automated intake assistant for Clara.'
 bot_about: 'Handles appointment scheduling and queries.'
@@ -33,3 +32,7 @@ open_times:
   - day: 6
     open: '14:00'
     close: '22:00'
+ngrok_authtoken: YOUR_NGROK_TOKEN
+dockerhub_repo: yourname/aurabot
+dockerhub_username: yourname
+dockerhub_password: yourpassword

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+flask
+requests
+openai==1.97.0
+python-dotenv
+pyyaml
+telethon
+pyngrok


### PR DESCRIPTION
## Summary
- package the bot in a Docker image and ignore build artifacts
- show how to install dependencies from `requirements.txt`
- expand example config with Docker Hub and ngrok settings
- integrate ngrok and Docker deployment in `setup_bot.py`

## Testing
- `python -m py_compile setup_bot.py`
- `python -m py_compile bot.py ai.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c4797748832f820cb79a39f2b6c0